### PR TITLE
fix error: unknown type name ' off_t' on suse

### DIFF
--- a/symbolizer.c
+++ b/symbolizer.c
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <sys/types.h>
 
 #include "backtrace.h"
 #include "internal.h"


### PR DESCRIPTION
os: suse 11 sp2  
gcc 4.91

```
In file included from ../../ianlancetaylor/cgosymbolizer/symbolizer.c:9:0:
../../ianlancetaylor/cgosymbolizer/internal.h:182:11: error: unknown type name ‘off_t’
           off_t offset, size_t size,
           ^
make: *** [build] Error 2
```
