### PR TITLE
include config.h in symbolizer.c to build on Alpine Linux

### DIFF
--- a/symbolizer.c
+++ b/symbolizer.c
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+#include "config.h"
+
 #include <stdint.h>
 #include <string.h>
 


### PR DESCRIPTION
backtrace.h will include stdint.h if the following condition is true:

    (defined(__GLIBC__) && __GLIBC__ >= 2) || HAVE_STDINT_H

Otherwise, it includes gstdint.h, a fallback supplied by an upstream build process that's not present here. To avoid this broken fallback, the config.h shipped by this library simply hardcodes `#define HAVE_STDINT_H 1`, which is a valid decision since all modern libc's provide stdint.h.

Upstream C source files (i.e., everything but symbolizer.c) always include config.h before including any other headers, so backtrace.h sees the correct define and does the right thing. symbolizer.c, however, does not include config.h, which means backtrace.h currently falls back to the broken gstdint.h when `__GLIBC__` is not defined. This happens on Alpine Linux, for example, which ships with musl libc instead of glibc.