### PR TITLE
[sles] sys/types.h must be included here to build

### DIFF
--- a/symbolizer.c
+++ b/symbolizer.c
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <sys/types.h>
 
 #include "backtrace.h"
 #include "internal.h"


### PR DESCRIPTION
I'm guessing that on SLES include order must be different and that was making the build fail. 

Adding this include here addressed the problem.