### PR TITLE
cgosymbolizer: recognize s390x in config.h

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,7 +1,7 @@
 /* Hand written config.h suitable for a modern GNU/Linux system.  */
 
 /* ELF size: 32 or 64 */
-#if defined(__x86_64__) || defined(__aarch64__) || defined(__mips64) || defined(_ARCH_PPC64)
+#if defined(__x86_64__) || defined(__aarch64__) || defined(__mips64) || defined(_ARCH_PPC64) || defined(__s390x__)
 #define BACKTRACE_ELF_SIZE 64
 #elif defined(__i386__) || defined(__arm__) || defined(__mips__) || defined(_ARCH_PPC)
 #define BACKTRACE_ELF_SIZE 32


### PR DESCRIPTION
CockroachDB relies on the library. However, the current lib doesn't have the support for the s390x. I think adding the change would allow for the  cockroachdb compilation on s390x machine to be successful. 