### PR TITLE
Update name of runtime function used, s/SetCgoSymbolizer/SetCgoTraceback/

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,4 @@
 A Go package that can be used to convert cgo function pointers into
 useful backtrace information.
 
-This is an experimental package intended for use with the proposed
-`runtime.SetCgoSymbolizer` function.
+This is an experimental package intended for use with the [`runtime.SetCgoTraceback`](https://golang.org/pkg/runtime/?m=all#SetCgoTraceback) function.

--- a/symbolizer.c
+++ b/symbolizer.c
@@ -76,7 +76,7 @@ static void syminfoCallback(void* data, uintptr_t pc, const char* symname, uintp
 	arg->entry = symval;
 }
 
-// For the details of how this is called see runtime.SetCgoSymbolizer.
+// For the details of how this is called see runtime.SetCgoTraceback.
 void cgoSymbolizer(void* parg) {
 	struct cgoSymbolizerArg* arg = (struct cgoSymbolizerArg*)(parg);
 	if (arg->data != 0) {


### PR DESCRIPTION
It appears that these comments were written before the proposed runtime function was included in Go.